### PR TITLE
Fix for HTTPS warnings.

### DIFF
--- a/app/code/community/Quafzi/PerformanceTweaks/Model/Observer.php
+++ b/app/code/community/Quafzi/PerformanceTweaks/Model/Observer.php
@@ -42,7 +42,8 @@ class Quafzi_PerformanceTweaks_Model_Observer
             $cacheKeyData = array(
                 Mage_Cms_Model_Block::CACHE_TAG,
                 $block->getBlockId(),
-                Mage::app()->getStore()->getId()
+                Mage::app()->getStore()->getId(),
+                intval(Mage::app()->getStore()->isCurrentlySecure())
             );
             $block->setCacheKey(implode('_', $cacheKeyData));
             $block->setCacheTags(array(Mage_Cms_Model_Block::CACHE_TAG));


### PR DESCRIPTION
When a CMS block got cached on a HTTP page and was shown on a HTTPS page, it caused warnings because there were HTTP images in the HTML.
Thanks @freakphp for investigating and creating this fix.
